### PR TITLE
Check for renamed/moved files when verify_all_files is false

### DIFF
--- a/lib/missing_codeowners/plugin.rb
+++ b/lib/missing_codeowners/plugin.rb
@@ -40,26 +40,31 @@ module Danger
     # @return   [Bool]
     attr_accessor :verbose
 
-    # Verifies git added and modified files for missing owners.
+    # Verifies files for missing owners.
     # Generates a `markdown` list of warnings for the prose in a corpus of
     # .markdown and .md files.
     #
+    # @param   [String] files
+    #          The list of files you want to verify, defaults to nil.
+    #          if nil, modified and added files from the diff will be used.
+    #
     # @return  [void]
     #
-    def verify
+    def verify(files = nil)
       @verify_all_files ||= false
       @max_number_of_files_to_report ||= 100
       @severity ||= "error"
       @verbose ||= false
 
-      files = files_to_verify
+      files_to_verify = files || files_from_git
+
       log "Files to verify:"
-      log files.join("\n")
+      log files_to_verify.join("\n")
 
       codeowners_path = find_codeowners_file
       codeowners_lines = read_codeowners_file(codeowners_path)
       codeowners_spec = parse_codeowners_spec(codeowners_lines)
-      @files_missing_codeowners = files.reject { |file| codeowners_spec.match file }
+      @files_missing_codeowners = files_to_verify.reject { |file| codeowners_spec.match file }
 
       if @files_missing_codeowners.any?
         log "Files missing CODEOWNERS:"
@@ -77,7 +82,7 @@ module Danger
 
     private
 
-    def files_to_verify
+    def files_from_git
       @verify_all_files == true ? git_all_files : git_modified_files
     end
 

--- a/lib/missing_codeowners/plugin.rb
+++ b/lib/missing_codeowners/plugin.rb
@@ -82,7 +82,10 @@ module Danger
     end
 
     def git_modified_files
-      git.added_files + git.modified_files
+      # This algorithm detects added files, modified files and renamed/moved files
+      renamed_files_hash = git.renamed_files.map { |rename| [rename[:before], rename[:after]] }.to_h
+      post_rename_modified_files = git.modified_files.map { |modified_file| renamed_files_hash[modified_file] || modified_file }
+      (post_rename_modified_files - git.deleted_files) + git.added_files
     end
 
     def git_all_files

--- a/spec/missing_codeowners_spec.rb
+++ b/spec/missing_codeowners_spec.rb
@@ -128,6 +128,22 @@ module Danger
           expect(@dangerfile.status_report[:markdowns].first.to_s).to include("2 other files")
           expect(@my_plugin.files_missing_codeowners.length).to eq(3)
         end
+
+        it "verifies added/modified/renamed files correctly when verify_all_files is false" do
+          @my_plugin.verify_all_files = false
+
+          allow(@my_plugin.git).to receive(:modified_files).and_return(["file_renamed_to_something_else.swift", "modified_file.swift"])
+          allow(@my_plugin.git).to receive(:renamed_files).and_return([{ before: "file_renamed_to_something_else.swift", after: "renamed_file.swift" }])
+          allow(@my_plugin.git).to receive(:added_files).and_return(["added_file.swift"])
+          allow(@my_plugin.git).to receive(:deleted_files).and_return(["deleted_file.swift"])
+
+          @my_plugin.verify
+
+          expect(@my_plugin.files_missing_codeowners).to include("added_file.swift")
+          expect(@my_plugin.files_missing_codeowners).to include("modified_file.swift")
+          expect(@my_plugin.files_missing_codeowners).to include("renamed_file.swift")
+          expect(@my_plugin.files_missing_codeowners.length).to eq(3)
+        end
       end
 
       context "and invalid CODEOWNERS file" do

--- a/spec/missing_codeowners_spec.rb
+++ b/spec/missing_codeowners_spec.rb
@@ -144,6 +144,17 @@ module Danger
           expect(@my_plugin.files_missing_codeowners).to include("renamed_file.swift")
           expect(@my_plugin.files_missing_codeowners.length).to eq(3)
         end
+
+        it "verifies only the provided files" do
+          @my_plugin.verify_all_files = true
+
+          allow(@my_plugin.git).to receive(:added_files).and_return(["added_file.swift"])
+
+          @my_plugin.verify(["added_file2.swift"])
+
+          expect(@my_plugin.files_missing_codeowners).to include("added_file2.swift")
+          expect(@my_plugin.files_missing_codeowners.length).to eq(1)
+        end
       end
 
       context "and invalid CODEOWNERS file" do


### PR DESCRIPTION
We are currently using `git.added_files + git.modified_files` when `@verify_all_files = false` and this is not working as expected when moving files using `git mv`, as `git.modified_files` is receiving the old file path the plugin is verifying the wrong path.

Refactored the logic to also consider `git.renamed_files` and the new file path after a move.