### PR TITLE
Add support for ignoring files

### DIFF
--- a/lib/missing_codeowners/plugin.rb
+++ b/lib/missing_codeowners/plugin.rb
@@ -40,6 +40,12 @@ module Danger
     # @return   [Bool]
     attr_accessor :verbose
 
+    # The list of files to ignore. These are naive prefixes, so `foo/`
+    # will match `foo/bar`. No globbing.
+    #
+    # @return [Array<String>]
+    attr_accessor :ignored_files
+
     # Verifies files for missing owners.
     # Generates a `markdown` list of warnings for the prose in a corpus of
     # .markdown and .md files.
@@ -47,16 +53,23 @@ module Danger
     # @param   [String] files
     #          The list of files you want to verify, defaults to nil.
     #          if nil, modified and added files from the diff will be used.
+    # @param   [String] ignored_files
+    #          The list of files you want to ignore, defaults to [].
+    #          The files are treated as prefixes, so `foo/` will match `foo/bar`.
     #
     # @return  [void]
     #
-    def verify(files = nil)
+    def verify(*opts)
       @verify_all_files ||= false
       @max_number_of_files_to_report ||= 100
       @severity ||= "error"
       @verbose ||= false
+      @ignored_files ||= opts.first.is_a?(Hash) ? opts.first[:ignored_files] : []
+      files = opts.first.is_a?(Hash) ? opts.first[:files] : opts.first
 
-      files_to_verify = files || files_from_git
+      files_to_verify = (files || files_from_git).delete_if {
+        |file| @ignored_files.any? { |ignored_file| file.start_with?(ignored_file) }
+      }
 
       log "Files to verify:"
       log files_to_verify.join("\n")

--- a/spec/missing_codeowners_spec.rb
+++ b/spec/missing_codeowners_spec.rb
@@ -155,6 +155,15 @@ module Danger
           expect(@my_plugin.files_missing_codeowners).to include("added_file2.swift")
           expect(@my_plugin.files_missing_codeowners.length).to eq(1)
         end
+
+        it "ignores explicitly ignored files" do
+          allow(@my_plugin).to receive(:git_modified_files).and_return(["ignored_file.swift", "added_file.swift"])
+
+          @my_plugin.verify(ignored_files: ["ignored_file.swift"])
+
+          expect(@my_plugin.files_missing_codeowners).to include("added_file.swift")
+          expect(@my_plugin.files_missing_codeowners.length).to eq(1)
+        end
       end
 
       context "and invalid CODEOWNERS file" do


### PR DESCRIPTION
This is a naive way of ignoring files, checking a list of proper prefixes instead of using more sophisticated globbing for simplicity's sake.